### PR TITLE
fixed go module path to github.com/hypermodeinc/dgo/v250 t

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dgraph-io/dgo/v250
+module github.com/hypermodeinc/dgo/v250
 
 go 1.23.8
 


### PR DESCRIPTION
Title: fix: update module path to github.com/hypermodeinc/dgo/v250

Description

Updated the Go module path from github.com/dgraph-io/dgo/v250 to github.com/hypermodeinc/dgo/v250 to reflect the correct repository location.

Checklist

-  Code compiles correctly and linting passes locally
- 
-  For all code changes, an entry added to the CHANGELOG.md file describing and linking to this PR
- 
-  Tests added for new functionality, or regression tests for bug fixes added as applicable